### PR TITLE
SimplePhp: fixed access to undefined property

### DIFF
--- a/Nextras/Migrations/Extensions/SimplePhp.php
+++ b/Nextras/Migrations/Extensions/SimplePhp.php
@@ -71,7 +71,7 @@ class SimplePhp implements IExtensionHandler
 	public function execute(File $sql)
 	{
 		extract($this->getParameters());
-		return include $sql->path;
+		return include $sql->getPath();
 	}
 
 }


### PR DESCRIPTION
Because entity File doesn't inherit Nette\Object, method getPath() must be called normally.
