### PR TITLE
Add `driver::unlock()` call

### DIFF
--- a/Nextras/Migrations/Engine/Runner.php
+++ b/Nextras/Migrations/Engine/Runner.php
@@ -114,6 +114,7 @@ class Runner
 				$this->printer->printExecute($file, $queriesCount);
 			}
 
+			$this->driver->unlock();
 			$this->printer->printDone();
 
 		} catch (Exception $e) {


### PR DESCRIPTION
Now it is needed to manually delete `migrations_lock` table, which is quite annoying.
