### PR TITLE
MysqlNetteDbDriver keeps collation of database

### DIFF
--- a/src/Drivers/MySqlNetteDbDriver.php
+++ b/src/Drivers/MySqlNetteDbDriver.php
@@ -34,8 +34,14 @@ class MySqlNetteDbDriver extends NetteDbDriver
 	{
 		$dbName = $this->context->fetchField('SELECT DATABASE()');
 		$dbName = $this->context->getConnection()->getSupplementalDriver()->delimite($dbName);
+
+		$collation = $this->context->fetch('SHOW VARIABLES LIKE "collation_database"');
+		if ($collation) {
+			$collation = $collation->Value;
+		}
+
 		$this->context->query('DROP DATABASE ' . $dbName);
-		$this->context->query('CREATE DATABASE ' . $dbName);
+		$this->context->query('CREATE DATABASE ' . $dbName . ($collation ? (' COLLATE="' . $collation . '"') : ''));
 		$this->context->query('USE ' . $dbName);
 	}
 


### PR DESCRIPTION
Currently, database's collation gets reset to mysql's default collation on `--reset`.
