### PR TITLE
Fixed namespace in DoctrineAdapter

### DIFF
--- a/src/Bridges/DoctrineDbal/DoctrineAdapter.php
+++ b/src/Bridges/DoctrineDbal/DoctrineAdapter.php
@@ -16,11 +16,11 @@ use Nextras\Migrations\IDbal;
 
 class DoctrineAdapter implements IDbal
 {
-	/** @var Doctrine\Dbal\Connection */
+	/** @var Doctrine\DBAL\Connection */
 	private $conn;
 
 
-	public function __construct(Doctrine\Dbal\Connection $conn)
+	public function __construct(Doctrine\DBAL\Connection $conn)
 	{
 		$this->conn = $conn;
 	}


### PR DESCRIPTION
Nette\DI\ServiceCreationException

Service 'migrations.dbal': Case mismatch on class name 'Doctrine\Dbal\Connection', correct name is 'Doctrine\DBAL\Connection'.