### PR TITLE
Fix problem with parallel execution of migrations in multiple databases in MySQL

### DIFF
--- a/src/Drivers/MySqlDriver.php
+++ b/src/Drivers/MySqlDriver.php
@@ -66,7 +66,7 @@ class MySqlDriver extends BaseDriver implements IDriver
 	public function lock()
 	{
 		$lock = $this->dbal->escapeString(self::LOCK_NAME);
-		$result = (int) $this->dbal->query("SELECT GET_LOCK($lock, 3) AS `result`")[0]['result'];
+		$result = (int) $this->dbal->query("SELECT GET_LOCK(CONCAT($lock, '-', DATABASE()), 3) AS `result`")[0]['result'];
 		if ($result !== 1) {
 			throw new LockException('Unable to acquire a lock.');
 		}
@@ -76,7 +76,7 @@ class MySqlDriver extends BaseDriver implements IDriver
 	public function unlock()
 	{
 		$lock = $this->dbal->escapeString(self::LOCK_NAME);
-		$result = (int) $this->dbal->query("SELECT RELEASE_LOCK($lock) AS `result`")[0]['result'];
+		$result = (int) $this->dbal->query("SELECT RELEASE_LOCK(CONCAT($lock, '-', DATABASE())) AS `result`")[0]['result'];
 		if ($result !== 1) {
 			throw new LockException('Unable to release a lock.');
 		}


### PR DESCRIPTION
I am using Nextras Migrations to initialize MySQL databases in integration tests. Each test uses a separate database for isolation.

The tests are running in parallel processes and they are sometimes failing, because the lock name is common for the whole MySQL server.

This could be solved by adding the database name to the lock name.