### PR TITLE
Config

### DIFF
--- a/src/Bridges/SymfonyConsole/BaseCommand.php
+++ b/src/Bridges/SymfonyConsole/BaseCommand.php
@@ -10,11 +10,9 @@
 namespace Nextras\Migrations\Bridges\SymfonyConsole;
 
 use Nextras\Migrations\Engine\Runner;
-use Nextras\Migrations\Entities\Group;
 use Nextras\Migrations\Extensions;
 use Nextras\Migrations\IConfiguration;
 use Nextras\Migrations\IDriver;
-use Nextras\Migrations\IPrinter;
 use Nextras\Migrations\Printers\Console;
 use Symfony\Component\Console\Command\Command;
 
@@ -23,27 +21,20 @@ abstract class BaseCommand extends Command
 {
 	/** @var IDriver */
 	protected $driver;
-	/** @var IConfiguration */
-	protected $devConfig;
 
 	/** @var IConfiguration */
-	protected $prodConfig;
-
-	/** @var array */
-	private $extensionHandlers;
+	protected $config;
 
 
 	/**
 	 * @param  IDriver        $driver
-	 * @param  IConfiguration $devConfig
-	 * @param  IConfiguration $prodConfig
+	 * @param  IConfiguration $config
 	 */
-	public function __construct(IDriver $driver, IConfiguration $devConfig, IConfiguration $prodConfig)
+	public function __construct(IDriver $driver, IConfiguration $config)
 	{
 		parent::__construct();
 		$this->driver = $driver;
-		$this->devConfig = $devConfig;
-		$this->prodConfig = $prodConfig;
+		$this->config = $config;
 	}
 
 
@@ -54,7 +45,7 @@ abstract class BaseCommand extends Command
 	 */
 	protected function runMigrations($mode, $config)
 	{
-		$printer = $this->getPrinter();
+		$printer = new Console();
 		$runner = new Runner($this->driver, $printer);
 		$runner->run($mode, $config);
 	}

--- a/src/Bridges/SymfonyConsole/BaseCommand.php
+++ b/src/Bridges/SymfonyConsole/BaseCommand.php
@@ -12,6 +12,7 @@ namespace Nextras\Migrations\Bridges\SymfonyConsole;
 use Nextras\Migrations\Engine\Runner;
 use Nextras\Migrations\Entities\Group;
 use Nextras\Migrations\Extensions;
+use Nextras\Migrations\IConfiguration;
 use Nextras\Migrations\IDriver;
 use Nextras\Migrations\IPrinter;
 use Nextras\Migrations\Printers\Console;
@@ -21,94 +22,41 @@ use Symfony\Component\Console\Command\Command;
 abstract class BaseCommand extends Command
 {
 	/** @var IDriver */
-	private $driver;
+	protected $driver;
+	/** @var IConfiguration */
+	protected $devConfig;
 
-	/** @var string */
-	private $dir;
+	/** @var IConfiguration */
+	protected $prodConfig;
 
 	/** @var array */
 	private $extensionHandlers;
 
 
 	/**
-	 * @param  IDriver $driver
-	 * @param  string  $dir
-	 * @param  array   $extensionHandlers
+	 * @param  IDriver        $driver
+	 * @param  IConfiguration $devConfig
+	 * @param  IConfiguration $prodConfig
 	 */
-	public function __construct(IDriver $driver, $dir, $extensionHandlers = [])
+	public function __construct(IDriver $driver, IConfiguration $devConfig, IConfiguration $prodConfig)
 	{
 		parent::__construct();
 		$this->driver = $driver;
-		$this->dir = $dir;
-		$this->extensionHandlers = $extensionHandlers;
+		$this->devConfig = $devConfig;
+		$this->prodConfig = $prodConfig;
 	}
 
 
 	/**
-	 * @param  string $mode Runner::MODE_*
-	 * @param  bool   $withDummy include dummy data?
+	 * @param  string         $mode Runner::MODE_*
+	 * @param  IConfiguration $config
 	 * @return void
 	 */
-	protected function runMigrations($mode, $withDummy)
+	protected function runMigrations($mode, $config)
 	{
 		$printer = $this->getPrinter();
 		$runner = new Runner($this->driver, $printer);
-
-		foreach ($this->getGroups($withDummy) as $group) {
-			$runner->addGroup($group);
-		}
-
-		foreach ($this->getExtensionHandlers() as $ext => $handler) {
-			$runner->addExtensionHandler($ext, $handler);
-		}
-
-		$runner->run($mode);
-	}
-
-
-	/**
-	 * @param  bool $withDummy
-	 * @return Group[]
-	 */
-	protected function getGroups($withDummy)
-	{
-		$structures = new Group();
-		$structures->enabled = TRUE;
-		$structures->name = 'structures';
-		$structures->directory = $this->dir . '/structures';
-		$structures->dependencies = [];
-
-		$basicData = new Group();
-		$basicData->enabled = TRUE;
-		$basicData->name = 'basic-data';
-		$basicData->directory = $this->dir . '/basic-data';
-		$basicData->dependencies = ['structures'];
-
-		$dummyData = new Group();
-		$dummyData->enabled = $withDummy;
-		$dummyData->name = 'dummy-data';
-		$dummyData->directory = $this->dir . '/dummy-data';
-		$dummyData->dependencies = ['structures', 'basic-data'];
-
-		return [$structures, $basicData, $dummyData];
-	}
-
-
-	/**
-	 * @return array (extension => IExtensionHandler)
-	 */
-	protected function getExtensionHandlers()
-	{
-		return $this->extensionHandlers;
-	}
-
-
-	/**
-	 * @return IPrinter
-	 */
-	protected function getPrinter()
-	{
-		return new Console();
+		$runner->run($mode, $config);
 	}
 
 }

--- a/src/Bridges/SymfonyConsole/ContinueCommand.php
+++ b/src/Bridges/SymfonyConsole/ContinueCommand.php
@@ -30,8 +30,8 @@ class ContinueCommand extends BaseCommand
 
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
-		$withDummy = !$input->getOption('production');
-		$this->runMigrations(Runner::MODE_CONTINUE, $withDummy);
+		$config = $input->getOption('production') ? $this->prodConfig : $this->devConfig;
+		$this->runMigrations(Runner::MODE_CONTINUE, $config);
 	}
 
 }

--- a/src/Bridges/SymfonyConsole/ContinueCommand.php
+++ b/src/Bridges/SymfonyConsole/ContinueCommand.php
@@ -13,7 +13,6 @@ use Nette;
 use Nextras\Migrations\Engine\Runner;
 use Nextras\Migrations\Extensions;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 
@@ -24,14 +23,12 @@ class ContinueCommand extends BaseCommand
 		$this->setName('migrations:continue');
 		$this->setDescription('Updates database schema by running all new migrations');
 		$this->setHelp("If table 'migrations' does not exist in current database, it is created automatically.");
-		$this->addOption('production', NULL, InputOption::VALUE_NONE, 'Will not import dummy data');
 	}
 
 
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
-		$config = $input->getOption('production') ? $this->prodConfig : $this->devConfig;
-		$this->runMigrations(Runner::MODE_CONTINUE, $config);
+		$this->runMigrations(Runner::MODE_CONTINUE, $this->config);
 	}
 
 }

--- a/src/Bridges/SymfonyConsole/CreateCommand.php
+++ b/src/Bridges/SymfonyConsole/CreateCommand.php
@@ -57,7 +57,7 @@ class CreateCommand extends BaseCommand
 	 */
 	private function getDirectory($type)
 	{
-		foreach ($this->getGroups(TRUE) as $group) {
+		foreach ($this->config->getGroups() as $group) {
 			if (Strings::startsWith($group->name, $type)) {
 				return $group->directory;
 			}

--- a/src/Bridges/SymfonyConsole/ResetCommand.php
+++ b/src/Bridges/SymfonyConsole/ResetCommand.php
@@ -30,8 +30,8 @@ class ResetCommand extends BaseCommand
 
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
-		$withDummy = !$input->getOption('production');
-		$this->runMigrations(Runner::MODE_RESET, $withDummy);
+		$config = $input->getOption('production') ? $this->prodConfig : $this->devConfig;
+		$this->runMigrations(Runner::MODE_RESET, $config);
 	}
 
 }

--- a/src/Bridges/SymfonyConsole/ResetCommand.php
+++ b/src/Bridges/SymfonyConsole/ResetCommand.php
@@ -13,7 +13,6 @@ use Nette;
 use Nextras\Migrations\Engine\Runner;
 use Nextras\Migrations\Extensions;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 
@@ -24,14 +23,12 @@ class ResetCommand extends BaseCommand
 		$this->setName('migrations:reset');
 		$this->setDescription('Drops current database and recreates it from scratch');
 		$this->setHelp("Drops current database and runs all migrations");
-		$this->addOption('production', NULL, InputOption::VALUE_NONE, 'Will not import dummy data');
 	}
 
 
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
-		$config = $input->getOption('production') ? $this->prodConfig : $this->devConfig;
-		$this->runMigrations(Runner::MODE_RESET, $config);
+		$this->runMigrations(Runner::MODE_RESET, $this->config);
 	}
 
 }

--- a/src/Configurations/DefaultConfiguration.php
+++ b/src/Configurations/DefaultConfiguration.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of the Nextras community extensions of Nette Framework
+ *
+ * @license    New BSD License
+ * @link       https://github.com/nextras/migrations
+ */
+
+namespace Nextras\Migrations\Configurations;
+
+use Nextras\Migrations\Entities\Group;
+use Nextras\Migrations\Extensions\PhpHandler;
+use Nextras\Migrations\Extensions\SqlHandler;
+use Nextras\Migrations\IConfiguration;
+use Nextras\Migrations\IDriver;
+use Nextras\Migrations\IPrinter;
+use Nextras\Migrations\Printers\Console;
+
+
+/**
+ * @author Jan Tvrdík
+ */
+class DefaultConfiguration implements IConfiguration
+{
+	/** @var IDriver */
+	protected $driver;
+
+	/** @var string */
+	protected $dir;
+
+	/** @var array */
+	protected $phpParams;
+
+	/** @var bool */
+	protected $withDummy;
+
+
+	/**
+	 * @param  IDriver $driver
+	 * @param  string  $dir
+	 * @param  array   $phpParams (name => value)
+	 * @param  bool    $withDummy
+	 */
+	public function __construct(IDriver $driver, $dir, $phpParams = [], $withDummy = TRUE)
+	{
+		$this->driver = $driver;
+		$this->dir = $dir;
+		$this->phpParams = $phpParams;
+		$this->withDummy = $withDummy;
+	}
+
+
+	/**
+	 * @return Group[]
+	 */
+	public function getGroups()
+	{
+		$structures = new Group();
+		$structures->enabled = TRUE;
+		$structures->name = 'structures';
+		$structures->directory = $this->dir . '/structures';
+		$structures->dependencies = [];
+
+		$basicData = new Group();
+		$basicData->enabled = TRUE;
+		$basicData->name = 'basic-data';
+		$basicData->directory = $this->dir . '/basic-data';
+		$basicData->dependencies = ['structures'];
+
+		$dummyData = new Group();
+		$dummyData->enabled = $this->withDummy;
+		$dummyData->name = 'dummy-data';
+		$dummyData->directory = $this->dir . '/dummy-data';
+		$dummyData->dependencies = ['structures', 'basic-data'];
+
+		return [$structures, $basicData, $dummyData];
+	}
+
+
+	/**
+	 * @return array (extension => IExtensionHandler)
+	 */
+	public function getExtensionHandlers()
+	{
+		return [
+			'sql' => new SqlHandler($this->driver),
+			'php' => new PhpHandler($this->phpParams),
+		];
+	}
+
+}

--- a/src/Configurations/DefaultConfiguration.php
+++ b/src/Configurations/DefaultConfiguration.php
@@ -10,12 +10,8 @@
 namespace Nextras\Migrations\Configurations;
 
 use Nextras\Migrations\Entities\Group;
-use Nextras\Migrations\Extensions\PhpHandler;
-use Nextras\Migrations\Extensions\SqlHandler;
 use Nextras\Migrations\IConfiguration;
-use Nextras\Migrations\IDriver;
-use Nextras\Migrations\IPrinter;
-use Nextras\Migrations\Printers\Console;
+use Nextras\Migrations\IExtensionHandler;
 
 
 /**
@@ -23,31 +19,26 @@ use Nextras\Migrations\Printers\Console;
  */
 class DefaultConfiguration implements IConfiguration
 {
-	/** @var IDriver */
-	protected $driver;
-
 	/** @var string */
 	protected $dir;
 
-	/** @var array */
-	protected $phpParams;
-
 	/** @var bool */
-	protected $withDummy;
+	protected $withDummyData;
+
+	/** @var IExtensionHandler[] */
+	protected $handlers;
 
 
 	/**
-	 * @param  IDriver $driver
-	 * @param  string  $dir
-	 * @param  array   $phpParams (name => value)
-	 * @param  bool    $withDummy
+	 * @param  string              $dir
+	 * @param  IExtensionHandler[] $handlers       (extension => IExtensionHandler)
+	 * @param  bool                $withDummyData
 	 */
-	public function __construct(IDriver $driver, $dir, $phpParams = [], $withDummy = TRUE)
+	public function __construct($dir, array $handlers, $withDummyData = TRUE)
 	{
-		$this->driver = $driver;
 		$this->dir = $dir;
-		$this->phpParams = $phpParams;
-		$this->withDummy = $withDummy;
+		$this->handlers = $handlers;
+		$this->withDummyData = $withDummyData;
 	}
 
 
@@ -69,7 +60,7 @@ class DefaultConfiguration implements IConfiguration
 		$basicData->dependencies = ['structures'];
 
 		$dummyData = new Group();
-		$dummyData->enabled = $this->withDummy;
+		$dummyData->enabled = $this->withDummyData;
 		$dummyData->name = 'dummy-data';
 		$dummyData->directory = $this->dir . '/dummy-data';
 		$dummyData->dependencies = ['structures', 'basic-data'];
@@ -79,14 +70,11 @@ class DefaultConfiguration implements IConfiguration
 
 
 	/**
-	 * @return array (extension => IExtensionHandler)
+	 * @return IExtensionHandler[] (extension => IExtensionHandler)
 	 */
 	public function getExtensionHandlers()
 	{
-		return [
-			'sql' => new SqlHandler($this->driver),
-			'php' => new PhpHandler($this->phpParams),
-		];
+		return $this->handlers;
 	}
 
 }

--- a/src/Engine/Runner.php
+++ b/src/Engine/Runner.php
@@ -15,6 +15,7 @@ use Nextras\Migrations\Entities\Group;
 use Nextras\Migrations\Entities\Migration;
 use Nextras\Migrations\Exception;
 use Nextras\Migrations\ExecutionException;
+use Nextras\Migrations\IConfiguration;
 use Nextras\Migrations\IDriver;
 use Nextras\Migrations\IExtensionHandler;
 use Nextras\Migrations\IPrinter;
@@ -80,11 +81,22 @@ class Runner
 
 
 	/**
-	 * @param  string $mode self::MODE_CONTINUE|self::MODE_RESET|self::MODE_INIT
+	 * @param  string         $mode self::MODE_CONTINUE|self::MODE_RESET|self::MODE_INIT
+	 * @param  IConfiguration $config
 	 * @return void
 	 */
-	public function run($mode = self::MODE_CONTINUE)
+	public function run($mode = self::MODE_CONTINUE, IConfiguration $config = NULL)
 	{
+		if ($config) {
+			foreach ($config->getGroups() as $group) {
+				$this->addGroup($group);
+			}
+
+			foreach ($config->getExtensionHandlers() as $ext => $handler) {
+				$this->addExtensionHandler($ext, $handler);
+			}
+		}
+
 		if ($mode === self::MODE_INIT) {
 			$this->printer->printSource($this->driver->getInitTableSource() . "\n");
 			$files = $this->finder->find($this->groups, array_keys($this->extensionsHandlers));

--- a/src/IConfiguration.php
+++ b/src/IConfiguration.php
@@ -9,6 +9,8 @@
 
 namespace Nextras\Migrations;
 
+use Nextras\Migrations\Entities\Group;
+
 
 /**
  * @author Jan Tvrdík
@@ -18,12 +20,12 @@ interface IConfiguration
 	/**
 	 * @return Group[]
 	 */
-	function getGroups();
+	public function getGroups();
 
 
 	/**
 	 * @return array (extension => IExtensionHandler)
 	 */
-	function getExtensionHandlers();
+	public function getExtensionHandlers();
 
 }

--- a/src/IConfiguration.php
+++ b/src/IConfiguration.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Nextras community extensions of Nette Framework
+ *
+ * @license    New BSD License
+ * @link       https://github.com/nextras/migrations
+ */
+
+namespace Nextras\Migrations;
+
+
+/**
+ * @author Jan Tvrdík
+ */
+interface IConfiguration
+{
+	/**
+	 * @return Group[]
+	 */
+	function getGroups();
+
+
+	/**
+	 * @return array (extension => IExtensionHandler)
+	 */
+	function getExtensionHandlers();
+
+}


### PR DESCRIPTION
revived https://github.com/nextras/migrations/tree/config

Refactored migration group definition to instance of configurator. 

Added:
- `Nextras\Migrations\Configurations\DefaultConfiguration`
- nette DI options:
  - `configuration` => `class name`
  - `withDummyData` => bool
  - `commands` => [`command name` => `class name`]

Changes:
- `--production` argument was removed and replaced with config `withDummyData` option