### PR TITLE
MigrationsExtension: add support for dynamic parameters in 'dir'

### DIFF
--- a/src/Bridges/NetteDI/MigrationsExtension.php
+++ b/src/Bridges/NetteDI/MigrationsExtension.php
@@ -52,7 +52,7 @@ class MigrationsExtension extends Nette\DI\CompilerExtension
 	{
 		$builder = $this->getContainerBuilder();
 		$config = $this->validateConfig($this->defaults);
-		Validators::assertField($config, 'dir', 'string');
+		Validators::assertField($config, 'dir', 'string|Nette\PhpGenerator\PhpLiteral');
 		Validators::assertField($config, 'phpParams', 'array');
 		Validators::assertField($config, 'contentSource', 'string|null');
 		Validators::assertField($config, 'ignoredQueriesFile', 'string|null');

--- a/tests/cases/integration/MigrationsExtension.dynamicParameters.neon
+++ b/tests/cases/integration/MigrationsExtension.dynamicParameters.neon
@@ -1,0 +1,7 @@
+migrations:
+	dir: %rootDir%/migrations
+	driver: mysql
+	dbal: dibi
+
+services:
+	- DibiConnection(%dibiConfig%)


### PR DESCRIPTION
Since Nette/DI 2.4.7 it's possible to use dynamic parameters but this means that parameter may contain PhpLiteral and not only string. This change adds support only for 'dir' config option.

See: https://github.com/nette/di/commit/2deccad0fd9de101fce63a635125b2c714cc0340

This is just first kick off...