### PR TITLE
Printers: fix duration time unit

### DIFF
--- a/src/Printers/Console.php
+++ b/src/Printers/Console.php
@@ -59,7 +59,7 @@ class Console implements IPrinter
 		$this->output(
 			'- ' . $file->group->name . '/' . $file->name . '; '
 			. $this->color($count, self::COLOR_INFO) . ' queries; '
-			. $this->color(sprintf('%0.3f', $time), self::COLOR_INFO) . ' ms'
+			. $this->color(sprintf('%0.3f', $time), self::COLOR_INFO) . ' s'
 		);
 	}
 

--- a/src/Printers/HtmlDump.php
+++ b/src/Printers/HtmlDump.php
@@ -55,7 +55,7 @@ class HtmlDump implements IPrinter
 		$format = '%0' . strlen($this->count) . 'd';
 		$name = htmlspecialchars($file->group->name . '/' . $file->name);
 		$this->output(sprintf(
-			$format . '/' . $format . ': <strong>%s</strong> (%d %s, %0.3f ms)',
+			$format . '/' . $format . ': <strong>%s</strong> (%d %s, %0.3f s)',
 			++$this->index, $this->count, $name, $count, ($count === 1 ? 'query' : 'queries'), $time
 		));
 	}

--- a/tests/cases/integration/Runner.FirstRun.phpt
+++ b/tests/cases/integration/Runner.FirstRun.phpt
@@ -24,11 +24,11 @@ class FirstRunTest extends IntegrationTestCase
 			'Nextras Migrations',
 			'RESET',
 			'5 migrations need to be executed.',
-			'- structures/001.sql; 1 queries; XX ms',
-			'- structures/002.sql; 1 queries; XX ms',
-			'- basic-data/003.sql; 2 queries; XX ms',
-			'- dummy-data/004.sql; 1 queries; XX ms',
-			'- structures/005.sql; 1 queries; XX ms',
+			'- structures/001.sql; 1 queries; XX s',
+			'- structures/002.sql; 1 queries; XX s',
+			'- basic-data/003.sql; 2 queries; XX s',
+			'- dummy-data/004.sql; 1 queries; XX s',
+			'- structures/005.sql; 1 queries; XX s',
 			'OK',
 		], $this->printer->lines);
 
@@ -62,11 +62,11 @@ class FirstRunTest extends IntegrationTestCase
 			'Nextras Migrations',
 			'CONTINUE',
 			'5 migrations need to be executed.',
-			'- structures/001.sql; 1 queries; XX ms',
-			'- structures/002.sql; 1 queries; XX ms',
-			'- basic-data/003.sql; 2 queries; XX ms',
-			'- dummy-data/004.sql; 1 queries; XX ms',
-			'- structures/005.sql; 1 queries; XX ms',
+			'- structures/001.sql; 1 queries; XX s',
+			'- structures/002.sql; 1 queries; XX s',
+			'- basic-data/003.sql; 2 queries; XX s',
+			'- dummy-data/004.sql; 1 queries; XX s',
+			'- structures/005.sql; 1 queries; XX s',
 			'OK',
 		], $this->printer->lines);
 

--- a/tests/cases/integration/Runner.SecondRun.phpt
+++ b/tests/cases/integration/Runner.SecondRun.phpt
@@ -27,11 +27,11 @@ class SecondRunTest extends IntegrationTestCase
 			'Nextras Migrations',
 			'RESET',
 			'5 migrations need to be executed.',
-			'- structures/001.sql; 1 queries; XX ms',
-			'- structures/002.sql; 1 queries; XX ms',
-			'- basic-data/003.sql; 2 queries; XX ms',
-			'- dummy-data/004.sql; 1 queries; XX ms',
-			'- structures/005.sql; 1 queries; XX ms',
+			'- structures/001.sql; 1 queries; XX s',
+			'- structures/002.sql; 1 queries; XX s',
+			'- basic-data/003.sql; 2 queries; XX s',
+			'- dummy-data/004.sql; 1 queries; XX s',
+			'- structures/005.sql; 1 queries; XX s',
 			'OK',
 		], $this->printer->lines);
 
@@ -49,8 +49,8 @@ class SecondRunTest extends IntegrationTestCase
 			'Nextras Migrations',
 			'CONTINUE',
 			'2 migrations need to be executed.',
-			'- dummy-data/004.sql; 1 queries; XX ms',
-			'- structures/005.sql; 1 queries; XX ms',
+			'- dummy-data/004.sql; 1 queries; XX s',
+			'- structures/005.sql; 1 queries; XX s',
 			'OK',
 		], $this->printer->lines);
 

--- a/tests/inc/TestPrinter.php
+++ b/tests/inc/TestPrinter.php
@@ -23,7 +23,7 @@ class TestPrinter extends Console
 
 	protected function output($s, $color = NULL)
 	{
-		$this->lines[] = preg_replace('#; \d+\.\d+ ms#', '; XX ms', $s);
+		$this->lines[] = preg_replace('#; \d+\.\d+ s#', '; XX s', $s);
 		$this->out .= "$s\n";
 	}
 }


### PR DESCRIPTION
Time in printers is printed in milliseconds but it's actually measured in seconds (because of `microtime(TRUE)`). This change fixes this incompatibility.

Not sure though if you want to fix the unit or fix the calculation...