### PR TITLE
simple plan impl

### DIFF
--- a/src/Bridges/SymfonyConsole/CreateCommand.php
+++ b/src/Bridges/SymfonyConsole/CreateCommand.php
@@ -11,6 +11,7 @@ namespace Nextras\Migrations\Bridges\SymfonyConsole;
 
 use Nette\Utils\Strings;
 use Nextras;
+use Nextras\Migrations\Engine\Plan;
 use Nextras\Migrations\Entities\Group;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -67,6 +68,10 @@ class CreateCommand extends BaseCommand
 		$group = $this->getGroup($input->getArgument('type'));
 		$path = $this->getPath($group, $input->getArgument('label'));
 		$content = $this->getFileContent($group, $this->getFileContentSource($input));
+
+		$planFile = $this->config->getPlanFile();
+		$plan = new Plan($planFile);
+		$plan->append($group, basename($path));
 
 		$this->createFile($path, $content, $output);
 		$output->writeln($path);

--- a/src/Configurations/DefaultConfiguration.php
+++ b/src/Configurations/DefaultConfiguration.php
@@ -131,4 +131,13 @@ class DefaultConfiguration implements IConfiguration
 		$this->dummyDataDiffGenerator = $generator;
 	}
 
+
+	/**
+	 * @return string
+	 */
+	public function getPlanFile()
+	{
+		return $this->dir . '/plan.tsv';
+	}
+
 }

--- a/src/Engine/Plan.php
+++ b/src/Engine/Plan.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace Nextras\Migrations\Engine;
+
+use Nextras\Migrations\Entities\Group;
+use Nextras\Migrations\PlanException;
+
+
+class Plan
+{
+
+	/** @var NULL|string */
+	private $planFile;
+
+
+	/**
+	 * @param NULL|string $planFile
+	 */
+	public function __construct($planFile)
+	{
+		$this->planFile = $planFile;
+	}
+
+
+	private function getEntries(): array
+	{
+		if ($this->planFile === NULL || !file_exists($this->planFile)) {
+			return [];
+		}
+
+		$raw = file_get_contents($this->planFile);
+		$lines = preg_split("~\r?\n\r?~", $raw, -1, PREG_SPLIT_NO_EMPTY);
+		return array_map(function(string $line) {
+			return explode("\t", $line);
+		}, $lines);
+	}
+
+
+	public function append(Group $group, string $name): void
+	{
+		$entries = $this->getEntries();
+		$lastEntry = array_shift($entries);
+
+		$ord = 0;
+		if ($lastEntry !== NULL) {
+			$ord = 1 + (int) $lastEntry[0];
+		}
+
+		file_put_contents($this->planFile, "$ord\t{$group->name}\t$name\n", FILE_APPEND);
+	}
+
+
+	public function validate(): void
+	{
+		$expectedOrd = 0;
+		foreach ($this->getEntries() as $entry) {
+			if ($expectedOrd !== (int) $entry[0]) {
+				$fmtEntry = $entry[1] . ': ' . $entry[2];
+				throw new PlanException("Execution plan violation: expected ord $expectedOrd, got $entry[0] ($fmtEntry).");
+			}
+			$expectedOrd++;
+		}
+	}
+
+}

--- a/src/Engine/Runner.php
+++ b/src/Engine/Runner.php
@@ -97,6 +97,9 @@ class Runner
 			}
 		}
 
+		$plan = new Plan($config->getPlanFile());
+		$plan->validate();
+
 		if ($mode === self::MODE_INIT) {
 			$this->printer->printSource($this->driver->getInitTableSource() . "\n");
 			$files = $this->finder->find($this->groups, array_keys($this->extensionsHandlers));

--- a/src/IConfiguration.php
+++ b/src/IConfiguration.php
@@ -28,4 +28,10 @@ interface IConfiguration
 	 */
 	public function getExtensionHandlers();
 
+
+	/**
+	 * @return NULL|string
+	 */
+	public function getPlanFile();
+
 }

--- a/src/exceptions.php
+++ b/src/exceptions.php
@@ -27,6 +27,14 @@ class LogicException extends \LogicException implements Exception
 
 
 /**
+ * Execution plan violation.
+ */
+class PlanException extends LogicException
+{
+}
+
+
+/**
  * Error during runtime.
  */
 abstract class RuntimeException extends \RuntimeException implements Exception


### PR DESCRIPTION
Closes #61 

Intentionally very simple implementation. More complex would require many changes to the core, such as splitting `OrderResolver`. This was started at https://github.com/Mikulas/migrations/tree/pr/exec-plan.

This proposed  solution is almost backwards compatible, with single exception of extending existing `IConfiguration` with `getPlanFile` method. However, the method is allowed to return `NULL`, in which case migrations completely skip all Plan code.

Plan entries are created only with `migrations:create` symfony command. The Plan is checked for validity whenever `Engine\Runner::run` is invoked.

IMO this solves the merge/rebase problem this was initially intended for, with minimal changes to the codebase.

<img width="862" alt="screenshot 2017-04-22 14 10 29" src="https://cloud.githubusercontent.com/assets/192200/25304338/95f2f1c4-2765-11e7-832a-b7a84a2923d0.png">