### PR TITLE
fix lock released after it cannot be acquired

### DIFF
--- a/src/Engine/Runner.php
+++ b/src/Engine/Runner.php
@@ -19,6 +19,7 @@ use Nextras\Migrations\IConfiguration;
 use Nextras\Migrations\IDriver;
 use Nextras\Migrations\IExtensionHandler;
 use Nextras\Migrations\IPrinter;
+use Nextras\Migrations\LockException;
 use Nextras\Migrations\LogicException;
 
 
@@ -129,6 +130,9 @@ class Runner
 
 			$this->driver->unlock();
 			$this->printer->printDone();
+
+		} catch (LockException $e) {
+			$this->printer->printError($e);
 
 		} catch (Exception $e) {
 			$this->driver->unlock();


### PR DESCRIPTION
Enginer\Runner first tries to Driver::lock() which throws
LockException. However, this exception was caught and Driver::unlock()
was called.

Issue:
- process A starts migrations, which creates a lock table
- process B also attempts to start migrations, but fails to acquire
  the lock and incorrectly removes the lock table
- process C can now also acquire the lock, even though process A did
  not yet release it

cc @matej21 