### PR TITLE
return unique error code when lock is not acquired

### DIFF
--- a/src/Drivers/PgSqlDriver.php
+++ b/src/Drivers/PgSqlDriver.php
@@ -97,7 +97,7 @@ class PgSqlDriver extends BaseDriver implements IDriver
 
 			$this->dbal->exec("CREATE TABLE {$this->schema}.{$this->lockTableName} (\"foo\" INT)");
 		} catch (\Exception $e) {
-			throw new LockException('Unable to acquire a lock.', NULL, $e);
+			throw new LockException('Unable to acquire a lock.', 3, $e);
 		}
 	}
 


### PR DESCRIPTION
This patch changes default error exit code 1 to 3 for this particular error. 2 was intentionally skipped as it is reserved for builtin misuse (http://tldp.org/LDP/abs/html/exitcodes.html#EXITCODESREF).

It is currently very hard to run migrations as a init container in kubernetes. This change will allow us to script around the issue.

Better fix would be option to select a blocking lock acquiring mechanism, but would overall be hard to configure and no easily changed just for deployment.