### PR TITLE
doc: added sort notice

### DIFF
--- a/doc/default.texy
+++ b/doc/default.texy
@@ -107,6 +107,10 @@ migrations
 └── run.php                              # start script if you don't
                                          # use Symfony Console Commands
 \--
+Notice
+------
+If you use Symfony commands then migrations are executed in alphabetical order (by filename).
+For example `dummy-data/2015-03-17_aaa.sql` is executed before`structures/2015-03-17_zzz.sql`.
 
 Optionally you can use **deep directory structure** which is suitable if you have a lot of migrations:
 

--- a/doc/default.texy
+++ b/doc/default.texy
@@ -91,6 +91,7 @@ Open the script in your browser (`HttpController`) or in a terminal (`ConsoleCon
 Organizing Migrations
 =====================
 
+Migrations are executed in alphabetical order (by filename), e.g. `structures/2015-03-17-aaa.sql` is executed before `dummy-data/2015-03-17-zzz.sql`.
 The following structure is recommended and used by Symfony Console Commands by default:
 
 /--
@@ -107,10 +108,6 @@ migrations
 └── run.php                              # start script if you don't
                                          # use Symfony Console Commands
 \--
-Notice
-------
-If you use Symfony commands then migrations are executed in alphabetical order (by filename).
-For example `dummy-data/2015-03-17_aaa.sql` is executed before`structures/2015-03-17_zzz.sql`.
 
 Optionally you can use **deep directory structure** which is suitable if you have a lot of migrations:
 


### PR DESCRIPTION
Migrations are sorted by filename if Symfony commands are used.

Not sure with English grammer.