### PR TITLE
Symfony 4 support

### DIFF
--- a/src/Bridges/DoctrineOrm/StructureDiffGenerator.php
+++ b/src/Bridges/DoctrineOrm/StructureDiffGenerator.php
@@ -9,7 +9,7 @@
 
 namespace Nextras\Migrations\Bridges\DoctrineOrm;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
 use Nextras;
 use Nextras\Migrations\IDiffGenerator;
@@ -18,7 +18,7 @@ use Nextras\Migrations\IDiffGenerator;
 class StructureDiffGenerator implements IDiffGenerator
 {
 
-	/** @var EntityManager */
+	/** @var EntityManagerInterface */
 	private $entityManager;
 
 	/** @var string|NULL absolute path to a file */
@@ -26,10 +26,10 @@ class StructureDiffGenerator implements IDiffGenerator
 
 
 	/**
-	 * @param EntityManager $entityManager
+	 * @param EntityManagerInterface $entityManager
 	 * @param string|NULL   $ignoredQueriesFile
 	 */
-	public function __construct(EntityManager $entityManager, $ignoredQueriesFile = NULL)
+	public function __construct(EntityManagerInterface $entityManager, $ignoredQueriesFile = NULL)
 	{
 		$this->entityManager = $entityManager;
 		$this->ignoredQueriesFile = $ignoredQueriesFile;

--- a/src/Bridges/SymfonyBundle/DependencyInjection/Configuration.php
+++ b/src/Bridges/SymfonyBundle/DependencyInjection/Configuration.php
@@ -18,7 +18,7 @@ class Configuration implements ConfigurationInterface
 	public function getConfigTreeBuilder()
 	{
 		$treeBuilder = new TreeBuilder();
-		$treeBuilder->root('nextras_migrations')->requiresAtLeastOneElement()->children()
+		$treeBuilder->root('nextras_migrations')->children()
 			->scalarNode('dir')
 				->defaultValue('%kernel.root_dir%/NextrasMigrations')
 				->cannotBeEmpty()

--- a/src/Bridges/SymfonyBundle/DependencyInjection/NextrasMigrationsExtension.php
+++ b/src/Bridges/SymfonyBundle/DependencyInjection/NextrasMigrationsExtension.php
@@ -49,7 +49,10 @@ class NextrasMigrationsExtension extends Extension
 			'nextras_migrations.dbal' => $dbalDefinition,
 			'nextras_migrations.driver' => $driverDefinition,
 		]);
-
+		$container->setAlias('Nextras\Migrations\IDriver', 'nextras_migrations.driver');
+		$container->setAlias('Nextras\Migrations\IDbal', 'nextras_migrations.dbal');
+		
+		
 		if ($config['diff_generator'] === 'doctrine') {
 			$structureDiffGeneratorDefinition = new Definition('Nextras\Migrations\Bridges\DoctrineOrm\StructureDiffGenerator');
 			$structureDiffGeneratorDefinition->setAutowired(TRUE);
@@ -69,7 +72,11 @@ class NextrasMigrationsExtension extends Extension
 		$configurationDefinition = new Definition('Nextras\Migrations\Configurations\DefaultConfiguration');
 		$configurationDefinition->setArguments([$config['dir'], $driverDefinition, $config['with_dummy_data'], $config['php_params']]);
 		$configurationDefinition->addMethodCall('setStructureDiffGenerator', [$structureDiffGeneratorDefinition]);
-
+		$container->addDefinitions([
+			'nextras_migrations.configuration' => $configurationDefinition,
+		]);
+		$container->setAlias('Nextras\Migrations\IConfiguration', 'nextras_migrations.configuration');
+		
 		$continueCommandDefinition = new Definition('Nextras\Migrations\Bridges\SymfonyConsole\ContinueCommand');
 		$continueCommandDefinition->setAutowired(TRUE);
 		$continueCommandDefinition->addTag('console.command');
@@ -83,7 +90,6 @@ class NextrasMigrationsExtension extends Extension
 		$resetCommandDefinition->addTag('console.command');
 
 		$container->addDefinitions([
-			'nextras_migrations.configuration' => $configurationDefinition,
 			'nextras_migrations.continue_command' => $continueCommandDefinition,
 			'nextras_migrations.create_command' => $createCommandDefinition,
 			'nextras_migrations.reset_command' => $resetCommandDefinition,


### PR DESCRIPTION
Bridges:Symfony:DependencyInjection Symfony 4.x compatibility
Bridges:DoctrineOrm: use EntityManagerInterface instead EntityManager
Bridges:Symfony:DependencyInjection add class aliases for symfony > 3.3