### PR TITLE
Lazy console command list

### DIFF
--- a/src/Bridges/SymfonyConsole/ContinueCommand.php
+++ b/src/Bridges/SymfonyConsole/ContinueCommand.php
@@ -19,11 +19,13 @@ class ContinueCommand extends BaseCommand
 	/** @var string */
 	protected static $defaultName = 'migrations:continue';
 
+	/** @var string */
+	protected static $defaultDescription = 'Updates database schema by running all new migrations';
 
 	protected function configure()
 	{
 		$this->setName(self::$defaultName);
-		$this->setDescription('Updates database schema by running all new migrations');
+		$this->setDescription(self::$defaultDescription);
 		$this->setHelp("If table 'migrations' does not exist in current database, it is created automatically.");
 	}
 

--- a/src/Bridges/SymfonyConsole/CreateCommand.php
+++ b/src/Bridges/SymfonyConsole/CreateCommand.php
@@ -29,6 +29,9 @@ class CreateCommand extends BaseCommand
 	protected static $defaultName = 'migrations:create';
 
 	/** @var string */
+	protected static $defaultDescription = 'Creates new migration file with proper name (e.g. 2015-03-14-130836-label.sql)';
+
+	/** @var string */
 	protected $defaultContentSource = self::CONTENT_SOURCE_DIFF;
 
 
@@ -48,7 +51,7 @@ class CreateCommand extends BaseCommand
 	protected function configure()
 	{
 		$this->setName(self::$defaultName);
-		$this->setDescription('Creates new migration file with proper name (e.g. 2015-03-14-130836-label.sql)');
+		$this->setDescription(self::$defaultDescription);
 		$this->setHelp('Prints path of the created file to standard output.');
 
 		$this->addArgument('type', InputArgument::REQUIRED, $this->getTypeArgDescription());

--- a/src/Bridges/SymfonyConsole/ResetCommand.php
+++ b/src/Bridges/SymfonyConsole/ResetCommand.php
@@ -19,10 +19,13 @@ class ResetCommand extends BaseCommand
 	/** @var string */
 	protected static $defaultName = 'migrations:reset';
 
+	/** @var string */
+	protected static $defaultDescription = 'Drops current database and recreates it from scratch';
+
 	protected function configure()
 	{
 		$this->setName(self::$defaultName);
-		$this->setDescription('Drops current database and recreates it from scratch');
+		$this->setDescription(self::$defaultDescription);
 		$this->setHelp("Drops current database and runs all migrations");
 	}
 


### PR DESCRIPTION
Since symfony/console 5.3 it's possible to lazy load command list. Only change required is to add `$defaultDescription` to commands

See https://github.com/symfony/symfony/pull/39851