### PR TITLE
Doctrine ORM 3.x & DBAL 4.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	"require-dev": {
 		"dibi/dibi": "~3.0 | ~4.0 | ~5.0",
 		"doctrine/cache": "~1.11 | ~2.0",
-		"doctrine/dbal": "~2.5 | ~3.0",
+		"doctrine/dbal": "^2.5 || ^3.0 || ^4.0",
 		"doctrine/orm": "^2.9 || ^3.0",
 		"mockery/mockery": "~1.3",
 		"nette/database": "~2.4 | ~3.0",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"dibi/dibi": "~3.0 | ~4.0 | ~5.0",
 		"doctrine/cache": "~1.11 | ~2.0",
 		"doctrine/dbal": "~2.5 | ~3.0",
-		"doctrine/orm": "~2.5",
+		"doctrine/orm": "^2.9 || ^3.0",
 		"mockery/mockery": "~1.3",
 		"nette/database": "~2.4 | ~3.0",
 		"nette/di": "~2.4.10 | ~3.0",

--- a/src/Bridges/DoctrineDbal/DoctrineAdapter.php
+++ b/src/Bridges/DoctrineDbal/DoctrineAdapter.php
@@ -56,7 +56,7 @@ class DoctrineAdapter implements IDbal
 
 	public function escapeBool(bool $value): string
 	{
-		return (string) $this->conn->getDatabasePlatform()->convertBooleans($value);
+		return $this->escapeString((string) (int) $value);
 	}
 
 

--- a/src/Bridges/DoctrineDbal/DoctrineAdapter.php
+++ b/src/Bridges/DoctrineDbal/DoctrineAdapter.php
@@ -44,30 +44,30 @@ class DoctrineAdapter implements IDbal
 
 	public function escapeString(string $value): string
 	{
-		return $this->conn->quote($value, 'string');
+		return $this->conn->getDatabasePlatform()->quoteStringLiteral($value);
 	}
 
 
 	public function escapeInt(int $value): string
 	{
-		return $this->conn->quote($value, 'integer');
+		return (string) $value;
 	}
 
 
 	public function escapeBool(bool $value): string
 	{
-		return $this->conn->quote($value, 'boolean');
+		return (string) $this->conn->getDatabasePlatform()->convertBooleans($value);
 	}
 
 
 	public function escapeDateTime(DateTimeInterface $value): string
 	{
-		return $this->conn->quote($value, 'datetime');
+		return $this->escapeString($value->format($this->conn->getDatabasePlatform()->getDateTimeFormatString()));
 	}
 
 
 	public function escapeIdentifier(string $value): string
 	{
-		return $this->conn->quoteIdentifier($value);
+		return $this->conn->getDatabasePlatform()->quoteIdentifier($value);
 	}
 }

--- a/src/Bridges/DoctrineOrm/StructureDiffGenerator.php
+++ b/src/Bridges/DoctrineOrm/StructureDiffGenerator.php
@@ -52,9 +52,9 @@ class StructureDiffGenerator implements IDiffGenerator
 	 */
 	protected function getUpdateQueries(): array
 	{
-		$cache = $this->entityManager->getConfiguration()->getMetadataCacheImpl();
-		if ($cache instanceof ClearableCache) {
-			$cache->deleteAll();
+		$cache = $this->entityManager->getConfiguration()->getMetadataCache();
+		if ($cache !== null) {
+			$cache->clear();
 		}
 
 		$schemaTool = new SchemaTool($this->entityManager);

--- a/tests/matrix/dbal/doctrine-4.0.sh
+++ b/tests/matrix/dbal/doctrine-4.0.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+PHP_VERSION_MIN="80100"
+PHP_VERSION_MAX="80399"
+COMPOSER_REQUIRE="$COMPOSER_REQUIRE doctrine/dbal:^4.0"
+COMPOSER_REQUIRE="$COMPOSER_REQUIRE nette/tester:~2.3"
+DBAL="doctrine"


### PR DESCRIPTION
`Configuration::getMetadataCacheImpl()` has been dropped in ORM 3.x, but a replacement in the form of `Configuration::getMetadataCache()` is available since ORM 2.9.
2.9 has been released in May 2019, IMO it's not worth trying to keep compatibility with ORM <2.9.