### PR TITLE
Replace built-in multi query parser with nextras/multi-query-parser

### DIFF
--- a/composer.bridgeless.json
+++ b/composer.bridgeless.json
@@ -1,4 +1,7 @@
 {
+	"require": {
+		"nextras/multi-query-parser": "^2.0"
+	},
 	"require-dev": {
 		"nette/tester": "^2.3",
 		"mockery/mockery": "^1.3"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
 	"type": "library",
 	"license": "BSD-3-Clause",
 	"require": {
-		"php": ">=8.0"
+		"php": ">=8.0",
+		"nextras/multi-query-parser": "^2.0"
 	},
 	"require-dev": {
 		"dibi/dibi": "^4.0 || ^5.0",

--- a/src/Drivers/MySqlDriver.php
+++ b/src/Drivers/MySqlDriver.php
@@ -13,6 +13,8 @@ use DateTime;
 use Nextras\Migrations\Entities\Migration;
 use Nextras\Migrations\IDriver;
 use Nextras\Migrations\LockException;
+use Nextras\MultiQueryParser\IMultiQueryParser;
+use Nextras\MultiQueryParser\MySqlMultiQueryParser;
 
 
 /**
@@ -23,6 +25,12 @@ use Nextras\Migrations\LockException;
 class MySqlDriver extends BaseDriver implements IDriver
 {
 	private const LOCK_NAME = 'Nextras.Migrations';
+
+
+	protected function createMultiQueryParser(): IMultiQueryParser
+	{
+		return new MySqlMultiQueryParser();
+	}
 
 
 	public function setupConnection(): void

--- a/src/Drivers/PgSqlDriver.php
+++ b/src/Drivers/PgSqlDriver.php
@@ -14,6 +14,8 @@ use Nextras\Migrations\Entities\Migration;
 use Nextras\Migrations\IDbal;
 use Nextras\Migrations\IDriver;
 use Nextras\Migrations\LockException;
+use Nextras\MultiQueryParser\IMultiQueryParser;
+use Nextras\MultiQueryParser\PostgreSqlMultiQueryParser;
 
 
 /**
@@ -29,6 +31,12 @@ class PgSqlDriver extends BaseDriver implements IDriver
 	public function __construct(IDbal $dbal, string $tableName = 'migrations', protected string $schema = 'public')
 	{
 		parent::__construct($dbal, $tableName);
+	}
+
+
+	protected function createMultiQueryParser(): IMultiQueryParser
+	{
+		return new PostgreSqlMultiQueryParser();
 	}
 
 


### PR DESCRIPTION
## Summary
- Adds `nextras/multi-query-parser` as a dependency
- Replaces the hand-rolled 75-line SQL parser in `BaseDriver::loadFile()` with calls to `IMultiQueryParser::parseFile()`
- Adds abstract `createMultiQueryParser()` to `BaseDriver`, implemented by `MySqlDriver` (→ `MySqlMultiQueryParser`) and `PgSqlDriver` (→ `PostgreSqlMultiQueryParser`)
- Updates unit tests to use the library's parser and adjusted expected values (the library trims leading whitespace/comments from queries)

## Test plan
- [x] All 26 unit tests pass
- [ ] Integration tests with MySQL
- [ ] Integration tests with PostgreSQL