### PR TITLE
Add PHPStan level 8 static analysis

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -13,6 +13,18 @@ on:
       - v*
 
 jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    name: PHPStan
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+      - run: composer install --no-interaction --no-progress
+      - run: vendor/bin/phpstan analyse --no-progress
+
   tests:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -23,6 +23,7 @@ jobs:
           php-version: '8.4'
           coverage: none
       - run: composer install --no-interaction --no-progress
+      - run: composer require --dev phpstan/phpstan:^2.1 --no-interaction --no-progress
       - run: vendor/bin/phpstan analyse --no-progress
 
   tests:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
 		"symfony/http-kernel": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
 		"symfony/yaml": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
 		"tracy/tracy": "^2.6",
-		"ext-openssl": "*"
+		"ext-openssl": "*",
+		"phpstan/phpstan": "^2.1"
 	},
 	"suggest": {
 		"dibi/dibi": "to use DibiAdapter",

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
 		"symfony/http-kernel": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
 		"symfony/yaml": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
 		"tracy/tracy": "^2.6",
-		"ext-openssl": "*",
-		"phpstan/phpstan": "^2.1"
+		"ext-openssl": "*"
 	},
 	"suggest": {
 		"dibi/dibi": "to use DibiAdapter",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,271 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Class dibi referenced with incorrect case\: Dibi\.$#'
+			identifier: class.nameCase
+			count: 1
+			path: src/Bridges/Dibi/Dibi3Adapter.php
+
+		-
+			message: '#^Method Nextras\\Migrations\\Bridges\\Dibi\\Dibi3Adapter\:\:query\(\) should return array\<int, array\<string, mixed\>\> but returns list\<Dibi\\Row&iterable\>\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Bridges/Dibi/Dibi3Adapter.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 1
+			path: src/Bridges/Dibi/DibiAdapter.php
+
+		-
+			message: '#^Call to an undefined method Doctrine\\DBAL\\Connection\:\:exec\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Bridges/DoctrineDbal/DoctrineAdapter.php
+
+		-
+			message: '#^Call to an undefined method Doctrine\\DBAL\\Connection\:\:fetchAll\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Bridges/DoctrineDbal/DoctrineAdapter.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Doctrine\\DBAL\\Connection and ''executeStatement'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Bridges/DoctrineDbal/DoctrineAdapter.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Doctrine\\DBAL\\Connection and ''fetchAllAssociative'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Bridges/DoctrineDbal/DoctrineAdapter.php
+
+		-
+			message: '#^Method Doctrine\\ORM\\Tools\\SchemaTool\:\:getUpdateSchemaSql\(\) invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/Bridges/DoctrineOrm/StructureDiffGenerator.php
+
+		-
+			message: '#^Anonymous function should return Nette\\PhpGenerator\\PhpLiteral but returns Nette\\PhpGenerator\\Literal\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Call to an undefined method Nette\\DI\\Definitions\\Definition\:\:addSetup\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Call to an undefined method Nette\\DI\\Definitions\\Definition\:\:getFactory\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Call to an undefined method Nette\\DI\\Definitions\\Definition\:\:setArguments\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''Nette\\\\DI\\\\Helpers'' and ''filterArguments'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Class Nette\\DI\\Statement does not have a constructor and must be instantiated without any parameters\.$#'
+			identifier: new.noConstructor
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Class dibi referenced with incorrect case\: Dibi\.$#'
+			identifier: class.nameCase
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Method Nextras\\Migrations\\Bridges\\NetteDI\\MigrationsExtension\:\:createConfigurationDefinition\(\) should return Nette\\DI\\ServiceDefinition but returns Nette\\DI\\Definitions\\ServiceDefinition\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Method Nextras\\Migrations\\Bridges\\NetteDI\\MigrationsExtension\:\:createDefaultGroupConfiguration\(\) should return array\<string, array\{enabled\?\: bool, directory\: string, dependencies\?\: list\<string\>, generator\?\: Nette\\DI\\ServiceDefinition\|null\}\> but returns array\{structures\: array\{enabled\?\: bool, directory\: Nette\\PhpGenerator\\PhpLiteral\|string, dependencies\?\: array\{0\: ''structures'', 1\?\: ''basic\-data''\}, generator\?\: Nette\\DI\\Definitions\\Definition\|null\}, basic\-data\: array\{enabled\?\: bool, directory\: Nette\\PhpGenerator\\PhpLiteral\|string, dependencies\?\: array\{0\: ''structures'', 1\?\: ''basic\-data''\}, generator\?\: Nette\\DI\\Definitions\\Definition\|null\}, dummy\-data\: array\{enabled\?\: bool, directory\: Nette\\PhpGenerator\\PhpLiteral\|string, dependencies\?\: array\{0\: ''structures'', 1\?\: ''basic\-data''\}, generator\?\: Nette\\DI\\Definitions\\Definition\|null\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Method Nextras\\Migrations\\Bridges\\NetteDI\\MigrationsExtension\:\:createDoctrineStructureDiffGeneratorDefinition\(\) should return Nette\\DI\\ServiceDefinition but returns Nette\\DI\\Definitions\\ServiceDefinition\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Method Nextras\\Migrations\\Bridges\\NetteDI\\MigrationsExtension\:\:createExtensionHandlerDefinitions\(\) should return list\<Nette\\DI\\ServiceDefinition\> but returns array\{Nette\\DI\\Definitions\\ServiceDefinition, Nette\\DI\\Definitions\\ServiceDefinition\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Method Nextras\\Migrations\\Bridges\\NetteDI\\MigrationsExtension\:\:createGroupDefinitions\(\) should return list\<Nette\\DI\\ServiceDefinition\> but returns list\<Nette\\DI\\Definitions\\ServiceDefinition\>\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Method Nextras\\Migrations\\Bridges\\NetteDI\\MigrationsExtension\:\:filterArguments\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Method Nextras\\Migrations\\Bridges\\NetteDI\\MigrationsExtension\:\:filterArguments\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Method Nextras\\Migrations\\Bridges\\NetteDI\\MigrationsExtension\:\:getDbalDefinition\(\) never returns Nette\\DI\\ServiceDefinition so it can be removed from the return type\.$#'
+			identifier: return.unusedType
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Method Nextras\\Migrations\\Bridges\\NetteDI\\MigrationsExtension\:\:getDbalDefinition\(\) should return Nette\\DI\\ServiceDefinition\|string but returns Nette\\DI\\Definitions\\ServiceDefinition\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Method Nextras\\Migrations\\Bridges\\NetteDI\\MigrationsExtension\:\:getDriverDefinition\(\) never returns Nette\\DI\\ServiceDefinition so it can be removed from the return type\.$#'
+			identifier: return.unusedType
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Method Nextras\\Migrations\\Bridges\\NetteDI\\MigrationsExtension\:\:getDriverDefinition\(\) should return Nette\\DI\\ServiceDefinition\|string but returns Nette\\DI\\Definitions\\ServiceDefinition\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Method Nextras\\Migrations\\Bridges\\NetteDI\\MigrationsExtension\:\:getPrinterDefinition\(\) never returns Nette\\DI\\ServiceDefinition so it can be removed from the return type\.$#'
+			identifier: return.unusedType
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Method Nextras\\Migrations\\Bridges\\NetteDI\\MigrationsExtension\:\:getPrinterDefinition\(\) should return Nette\\DI\\ServiceDefinition\|string but returns Nette\\DI\\Definitions\\ServiceDefinition\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Parameter \#1 \$factory of method Nette\\DI\\Definitions\\ServiceDefinition\:\:setFactory\(\) expects array\|Nette\\DI\\Definitions\\Definition\|Nette\\DI\\Definitions\\Reference\|Nette\\DI\\Definitions\\Statement\|string, Nette\\DI\\Statement\|string given\.$#'
+			identifier: argument.type
+			count: 3
+			path: src/Bridges/NetteDI/MigrationsExtension.php
+
+		-
+			message: '#^Method Nextras\\Migrations\\Bridges\\NetteDatabase\\NetteAdapter\:\:exec\(\) should return int but returns int\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Bridges/NetteDatabase/NetteAdapter.php
+
+		-
+			message: '#^Parameter \#1 \$sql of method Nette\\Database\\Connection\:\:fetchAll\(\) expects literal\-string, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Bridges/NetteDatabase/NetteAdapter.php
+
+		-
+			message: '#^Parameter \#1 \$sql of method Nette\\Database\\Connection\:\:query\(\) expects literal\-string, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Bridges/NetteDatabase/NetteAdapter.php
+
+		-
+			message: '#^Access to undefined constant Nextras\\Dbal\\Drivers\\IDriver\:\:TYPE_BOOL\.$#'
+			identifier: classConstant.notFound
+			count: 1
+			path: src/Bridges/NextrasDbal/NextrasAdapter.php
+
+		-
+			message: '#^Access to undefined constant Nextras\\Dbal\\Drivers\\IDriver\:\:TYPE_DATETIME\.$#'
+			identifier: classConstant.notFound
+			count: 1
+			path: src/Bridges/NextrasDbal/NextrasAdapter.php
+
+		-
+			message: '#^Access to undefined constant Nextras\\Dbal\\Drivers\\IDriver\:\:TYPE_IDENTIFIER\.$#'
+			identifier: classConstant.notFound
+			count: 1
+			path: src/Bridges/NextrasDbal/NextrasAdapter.php
+
+		-
+			message: '#^Access to undefined constant Nextras\\Dbal\\Drivers\\IDriver\:\:TYPE_STRING\.$#'
+			identifier: classConstant.notFound
+			count: 1
+			path: src/Bridges/NextrasDbal/NextrasAdapter.php
+
+		-
+			message: '#^Call to an undefined method Nextras\\Dbal\\Drivers\\IDriver\:\:convertBoolToSql\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Bridges/NextrasDbal/NextrasAdapter.php
+
+		-
+			message: '#^Call to an undefined method Nextras\\Dbal\\Drivers\\IDriver\:\:convertDateTimeToSql\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Bridges/NextrasDbal/NextrasAdapter.php
+
+		-
+			message: '#^Call to an undefined method Nextras\\Dbal\\Drivers\\IDriver\:\:convertIdentifierToSql\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Bridges/NextrasDbal/NextrasAdapter.php
+
+		-
+			message: '#^Call to an undefined method Nextras\\Dbal\\Drivers\\IDriver\:\:convertToSql\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: src/Bridges/NextrasDbal/NextrasAdapter.php
+
+		-
+			message: '#^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<string\>\:\:root\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Bridges/SymfonyBundle/DependencyInjection/Configuration.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\TreeBuilder'' and ''__construct'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Bridges/SymfonyBundle/DependencyInjection/Configuration.php
+
+		-
+			message: '#^Class Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder constructor invoked with 0 parameters, 1\-3 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/Bridges/SymfonyBundle/DependencyInjection/Configuration.php
+
+		-
+			message: '#^Property Nextras\\Migrations\\Controllers\\HttpController\:\:\$error is never written, only read\.$#'
+			identifier: property.onlyRead
+			count: 1
+			path: src/Controllers/HttpController.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: src/Controllers/HttpController.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+includes:
+	- phpstan-baseline.neon
+parameters:
+	level: 8
+	paths:
+		- src

--- a/src/Bridges/DoctrineOrm/StructureDiffGenerator.php
+++ b/src/Bridges/DoctrineOrm/StructureDiffGenerator.php
@@ -75,8 +75,12 @@ class StructureDiffGenerator implements IDiffGenerator
 		}
 
 		$content = file_get_contents($this->ignoredQueriesFile);
+		if ($content === false) {
+			return [];
+		}
+
 		$queries = preg_split('~(\s*;\s*\r?\n|\z)~', $content, -1, PREG_SPLIT_NO_EMPTY);
 
-		return $queries;
+		return $queries !== false ? $queries : [];
 	}
 }

--- a/src/Bridges/SymfonyConsole/CreateCommand.php
+++ b/src/Bridges/SymfonyConsole/CreateCommand.php
@@ -83,7 +83,7 @@ class CreateCommand extends BaseCommand
 		$extension = $group->generator ? $group->generator->getExtension() : 'sql';
 		$name = $this->getFileName($label, $extension);
 
-		if ($this->hasNumericSubdirectory($dir, $foundYear)) {
+		if ($this->hasNumericSubdirectory($dir, $foundYear) && $foundYear !== null) {
 			if ($this->hasNumericSubdirectory($foundYear, $foundMonth)) {
 				return $dir . date('/Y/m/') . $name;
 

--- a/src/Configurations/DefaultConfiguration.php
+++ b/src/Configurations/DefaultConfiguration.php
@@ -36,10 +36,10 @@ class DefaultConfiguration implements IConfiguration
 	/** @var array<string, mixed> */
 	protected $phpParams;
 
-	/** @var list<Group> */
+	/** @var list<Group>|null */
 	protected $groups;
 
-	/** @var array<string, IExtensionHandler> */
+	/** @var array<string, IExtensionHandler>|null */
 	protected $handlers;
 
 	/** @var ?IDiffGenerator */

--- a/src/Controllers/BaseController.php
+++ b/src/Controllers/BaseController.php
@@ -21,7 +21,7 @@ abstract class BaseController
 	/** @var Engine\Runner */
 	protected $runner;
 
-	/** @var string */
+	/** @var Engine\Runner::MODE_* */
 	protected $mode;
 
 	/** @var array<string, Group> (name => Group) */

--- a/src/Drivers/BaseDriver.php
+++ b/src/Drivers/BaseDriver.php
@@ -27,8 +27,8 @@ abstract class BaseDriver implements IDriver
 	/** @var string */
 	protected $tableName;
 
-	/** @var null|string */
-	protected $tableNameQuoted;
+	/** @var string */
+	protected $tableNameQuoted = '';
 
 
 	public function __construct(IDbal $dbal, string $tableName = 'migrations')
@@ -86,6 +86,7 @@ abstract class BaseDriver implements IDriver
 				$parseRe = '(' . preg_quote($delimiter) . "|$openRe)";
 			}
 
+			$queryLength = 0;
 			while (true) {
 				preg_match($parseRe, $content, $match, PREG_OFFSET_CAPTURE, $parseOffset); // should always match
 				$found = $match[0][0];

--- a/src/Drivers/MySqlDriver.php
+++ b/src/Drivers/MySqlDriver.php
@@ -158,7 +158,7 @@ class MySqlDriver extends BaseDriver implements IDriver
 
 	public function getInitTableSource(): string
 	{
-		return preg_replace('#^\t{3}#m', '', trim("
+		return (string) preg_replace('#^\t{3}#m', '', trim("
 			CREATE TABLE IF NOT EXISTS {$this->tableNameQuoted} (
 				`id` int(10) unsigned NOT NULL AUTO_INCREMENT,
 				`group` varchar(100) NOT NULL,

--- a/src/Drivers/PgSqlDriver.php
+++ b/src/Drivers/PgSqlDriver.php
@@ -26,8 +26,8 @@ class PgSqlDriver extends BaseDriver implements IDriver
 	/** @var string */
 	protected $schema;
 
-	/** @var null|string */
-	protected $schemaQuoted;
+	/** @var string */
+	protected $schemaQuoted = '';
 
 
 	public function __construct(IDbal $dbal, string $tableName = 'migrations', string $schema = 'public')
@@ -163,7 +163,7 @@ class PgSqlDriver extends BaseDriver implements IDriver
 
 	public function getInitTableSource(): string
 	{
-		return preg_replace('#^\t{3}#m', '', trim("
+		return (string) preg_replace('#^\t{3}#m', '', trim("
 			CREATE TABLE IF NOT EXISTS {$this->schemaQuoted}.{$this->tableNameQuoted} (" . '
 				"id" serial4 NOT NULL,
 				"group" varchar(100) NOT NULL,


### PR DESCRIPTION
## Summary
- Adds PHPStan 2.x at level 8 with a baseline for multi-version bridge compatibility errors
- Fixes real type issues in driver code, configuration, and controllers
- Adds a PHPStan CI job running on PHP 8.4

## Inline fixes
- **BaseDriver/PgSqlDriver**: Changed `$tableNameQuoted`/`$schemaQuoted` from `null|string` to `string` with `''` default
- **MySqlDriver/PgSqlDriver**: Cast `preg_replace` return to `(string)` in `getInitTableSource()`
- **BaseDriver**: Initialized `$queryLength` before inner loop to satisfy flow analysis
- **DefaultConfiguration**: Fixed lazy-init property types to `list<Group>|null` / `array<string, IExtensionHandler>|null`
- **StructureDiffGenerator**: Added `false` checks for `file_get_contents()` and `preg_split()`
- **BaseController**: Changed `$mode` type to `Engine\Runner::MODE_*`
- **CreateCommand**: Added null guard for `$foundYear` out-parameter

## Baseline (50 errors)
Bridge code uses `method_exists()` checks to support multiple library versions. PHPStan can only see the installed version, so it flags calls to methods from other versions as errors. These are baselined:
- Doctrine DBAL (`fetchAll()`, `exec()` removed in 4.x) and ORM (`getUpdateSchemaSql()` signature change)
- Nextras DBAL (`convertToSql`, `convertBoolToSql`, `TYPE_*` constants from older versions)
- Nette Database (`literal-string` param, `getRowCount()` nullability)
- Nette DI (`ServiceDefinition` vs `Definitions\ServiceDefinition`, `Statement` constructor, etc.)
- Symfony Config (`TreeBuilder` constructor change)
- Dibi (`dibi` class name casing, `query()` return type)
- HttpController (`goto` flow analysis limitation)

## Test plan
- [x] `vendor/bin/phpstan analyse --no-progress` reports 0 errors
- [x] `tests/run-unit.sh` passes (26 tests)
- [ ] CI phpstan job passes on PHP 8.4